### PR TITLE
Use Net::HTTP::Persistent

### DIFF
--- a/fluent-plugin-out-http.gemspec
+++ b/fluent-plugin-out-http.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version  = '>= 2.1.0'
 
   gem.add_runtime_dependency "yajl-ruby", "~> 1.0"
+  gem.add_runtime_dependency "net-http-persistent"
   gem.add_runtime_dependency "fluentd", [">= 0.14.22", "< 2"]
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "rake"


### PR DESCRIPTION
In order to alleviate creating one connection per log line, use the Net::HTTP::Persistent library to wrap requests in order to reuse connections.

This also no longer gives the option to turn off SSL (only skip verification), so tests had to be modified in order to pass. Authentication and certs also had to be reworked, but since we are not using those I temporarily just skipped dealing with them for now.